### PR TITLE
Cleaned up Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .github
 .gitignore
 CODEOWNERS
-Dockerfile
 Jenkinsfile
 LICENSE
 README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.DS_Store
+.git
+.github
+.gitignore
+CODEOWNERS
+Dockerfile
+Jenkinsfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,38 +3,37 @@ FROM ubuntu:16.04
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r kibana && useradd -r -m -g kibana kibana
 
-RUN apt-get update && apt-get install -y \
-		apt-transport-https \
-		ca-certificates \
-		wget \
-# generating PDFs requires libfontconfig and libfreetype6
-		libfontconfig \
-		libfreetype6 \
-	--no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN buildDeps='apt-transport-https 
+			libfontconfig 
+			libfreetype6
+			wget' && \
+    apt-get -qq update && \
+    apt-get install -y -qq $buildDeps ca-certificates --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
-RUN set -x \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& gosu nobody true
+RUN set -x && \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" && \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" && \
+	export GNUPGHOME="$(mktemp -d)" && \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
+	chmod +x /usr/local/bin/gosu && \
+	gosu nobody true
 
 # grab tini for signal processing and zombie killing
 ENV TINI_VERSION v0.9.0
-RUN set -x \
-	&& wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini" \
-	&& wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc" \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
-	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-	&& rm -rf "$GNUPGHOME" /usr/local/bin/tini.asc \
-	&& chmod +x /usr/local/bin/tini \
-	&& tini -h
+RUN set -x && \
+	wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini" && \
+	wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc" && \
+	export GNUPGHOME="$(mktemp -d)" && \
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 && \
+	gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini && \
+	rm -rf "$GNUPGHOME" /usr/local/bin/tini.asc && \
+	chmod +x /usr/local/bin/tini && \
+	tini -h
 
 RUN set -ex; \
 # https://artifacts.elastic.co/GPG-KEY-elasticsearch
@@ -50,18 +49,17 @@ RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/
 
 ENV KIBANA_VERSION 5.4.2
 
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
-	\
+RUN set -x && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends kibana=$KIBANA_VERSION && \
+	rm -rf /var/lib/apt/lists/* && \
 # the default "server.host" is "localhost" in 5+
-	&& sed -ri "s!^(\#\s*)?(server\.host:).*!\2 '0.0.0.0'!" /etc/kibana/kibana.yml \
-	&& grep -q "^server\.host: '0.0.0.0'\$" /etc/kibana/kibana.yml \
-	\
+	sed -ri "s!^(\#\s*)?(server\.host:).*!\2 '0.0.0.0'!" /etc/kibana/kibana.yml && \
+	grep -q "^server\.host: '0.0.0.0'\$" /etc/kibana/kibana.yml && \
 # ensure the default configuration is useful when using --link
-	&& sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /etc/kibana/kibana.yml \
-	&& grep -q "^elasticsearch\.url: 'http://elasticsearch:9200'\$" /etc/kibana/kibana.yml
+	sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /etc/kibana/kibana.yml && \
+	grep -q "^elasticsearch\.url: 'http://elasticsearch:9200'\$" /etc/kibana/kibana.yml && \
+	apt-get remove --purge --auto-remove -y -qq $buildDeps perl
 
 ENV PATH /usr/share/kibana/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:16.04
 
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r kibana && useradd -r -m -g kibana kibana

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu:16.04
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r kibana && useradd -r -m -g kibana kibana
 
-RUN buildDeps='apt-transport-https 
-			libfontconfig 
-			libfreetype6
+RUN buildDeps='apt-transport-https \
+			libfontconfig \
+			libfreetype6 \
 			wget' && \
     apt-get -qq update && \
     apt-get install -y -qq $buildDeps ca-certificates --no-install-recommends && \


### PR DESCRIPTION
added .dockerignore, added buildDeps var to Dockerfile and ordered deps alphabetically, changed base distro

**What this PR does / why we need it**:
Reduced docker image size from 124.2 MB to 105.1 MB.
Reduced total image security vulnerabilities from 81 to  57 
Reduced "high" level vulnerabilities from 10 to 0
Reduced "medium" level vulnerabilities from 26 to 21

https://github.com/samsung-cnct/issues/issues/71 that is currently blocked until the new CI is done will continue this work. Line 62 of the Dockerfile in this PR tries to manually cleanup artifacts but the multi-stage builds are a better fix for the long-term. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
Related to: https://github.com/samsung-cnct/issues/issues/68