### PR TITLE
upgraded version to 5.2.2  *DO NOT MERGE*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
 # https://www.elastic.co/guide/en/kibana/5.0/deb.html
 RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/kibana.list
 
-ENV KIBANA_VERSION 5.6.3
+ENV KIBANA_VERSION 5.2.2 
 
 RUN set -x && \
 	apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
 # https://www.elastic.co/guide/en/kibana/5.0/deb.html
 RUN echo 'deb https://artifacts.elastic.co/packages/5.x/apt stable main' > /etc/apt/sources.list.d/kibana.list
 
-ENV KIBANA_VERSION 5.5.2
+ENV KIBANA_VERSION 5.6.3
 
 RUN set -x && \
 	apt-get update && \


### PR DESCRIPTION
This is to match the current version of Elasticsearch: https://github.com/samsung-cnct/container-elasticsearch/pull/7

I need to update the ES chart, then we will merge all 3 at the same time.